### PR TITLE
feat: multiple regex styles in container name matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ spec:
     matchAny:
     - pod: nginx-pod
       namespace: default
-      containerName: ".*"
+      containerName: "rgex:nginx-.*"
       matchLabels:
         security-level: high
     metadata:

--- a/api/v1/kivedata_conversion.go
+++ b/api/v1/kivedata_conversion.go
@@ -25,7 +25,6 @@ func (src *KiveData) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.InodeNo = src.Spec.InodeNo
 	dst.Spec.DevID = src.Spec.DevID
-	dst.Spec.KernelID = src.Spec.KernelID
 
 	return nil
 }
@@ -38,7 +37,6 @@ func (dst *KiveData) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dst.Spec.InodeNo = src.Spec.InodeNo
 	dst.Spec.DevID = src.Spec.DevID
-	dst.Spec.KernelID = src.Spec.KernelID
 
 	return nil
 }

--- a/api/v1/kivedata_types.go
+++ b/api/v1/kivedata_types.go
@@ -22,8 +22,6 @@ type KiveDataSpec struct {
 	InodeNo uint64 `json:"inode-no,omitempty"`
 	// The device number of the inode
 	DevID uint32 `json:"dev-id,omitempty"`
-	// A string to uniquely identify a running kernel
-	KernelID string `json:"kernel-id,omitempty"`
 	// (optional) Additional information
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/api/v1/kivetrap_type.go
+++ b/api/v1/kivetrap_type.go
@@ -35,7 +35,7 @@ type KiveTrapMatch struct {
 	//  - if this field is prepended by "regex:", the rest of the string
 	//    will represent a regular expression matched with go regexp
 	//    library (https://golang.org/s/re2syntax)
-	//  - if the fiels is prepended by "glob:", then this is a
+	//  - if the field is prepended by "glob:", then this is a
 	//    filesystem-style regex, as described in go filepath.Match
 	//    library (https://pkg.go.dev/path/filepath#Match)
 	//  - otherwise, the name of the container will be compared exactly

--- a/api/v1/kivetrap_type.go
+++ b/api/v1/kivetrap_type.go
@@ -31,8 +31,14 @@ type KiveTrap struct {
 type KiveTrapMatch struct {
 	// Filter pods by name
 	PodName string `json:"pod,omitempty"`
-	// Filter container by name, can be a regex with syntax described at
-	// https://golang.org/s/re2syntax
+	// Filter container by name.
+	//  - if this field is prepended by "regex:", the rest of the string
+	//    will represent a regular expression matched with go regexp
+	//    library (https://golang.org/s/re2syntax)
+	//  - if the fiels is prepended by "glob:", then this is a
+	//    filesystem-style regex, as described in go filepath.Match
+	//    library (https://pkg.go.dev/path/filepath#Match)
+	//  - otherwise, the name of the container will be compared exactly
 	ContainerName string `json:"containerName,omitempty"`
 	// Filter pods by namespace
 	Namespace string `json:"namespace,omitempty"`

--- a/api/v2alpha1/kivedata_types.go
+++ b/api/v2alpha1/kivedata_types.go
@@ -24,8 +24,6 @@ type KiveDataSpec struct {
 	InodeNo uint64 `json:"inodeNo,omitempty"`
 	// The device number of the inode
 	DevID uint32 `json:"dev-id,omitempty"`
-	// A string to uniquely identify a running kernel
-	KernelID string `json:"kernelId,omitempty"`
 	// (optional) Additional information
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/api/v2alpha1/kivetrap_type.go
+++ b/api/v2alpha1/kivetrap_type.go
@@ -31,8 +31,14 @@ type KiveTrap struct {
 type KiveTrapMatch struct {
 	// Filter pods by name
 	PodName string `json:"pod,omitempty"`
-	// Filter container by name, can be a regex with syntax described at
-	// https://golang.org/s/re2syntax
+	// Filter container by name.
+	//  - if this field is prepended by "regex:", the rest of the string
+	//    will represent a regular expression matched with go regexp
+	//    library (https://golang.org/s/re2syntax)
+	//  - if the fiels is prepended by "glob:", then this is a
+	//    filesystem-style regex, as described in go filepath.Match
+	//    library (https://pkg.go.dev/path/filepath#Match)
+	//  - otherwise, the name of the container will be compared exactly
 	ContainerName string `json:"containerName,omitempty"`
 	// Filter pods by namespace
 	Namespace string `json:"namespace,omitempty"`

--- a/bundle/manifests/kivebpf.clusterserviceversion.yaml
+++ b/bundle/manifests/kivebpf.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ metadata:
                 "create": true,
                 "matchAny": [
                   {
-                    "container-name": ".*",
+                    "containerName": "regex:ngi.*",
                     "namespace": "default"
                   }
                 ],
@@ -136,7 +136,7 @@ metadata:
                 "create": true,
                 "matchAny": [
                   {
-                    "container-name": "123.*",
+                    "containerName": "regex:123.*",
                     "namespace": "default",
                     "pod": "nginx-pod"
                   }
@@ -216,7 +216,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-13T18:02:46Z"
+    createdAt: "2025-08-13T19:37:00Z"
     operators.operatorframework.io.bundle.channels.v1: stable,alpha
     operators.operatorframework.io.bundle.default.channel.v1: stable
     operators.operatorframework.io/builder: operator-sdk-v1.39.1

--- a/bundle/manifests/kivebpf.clusterserviceversion.yaml
+++ b/bundle/manifests/kivebpf.clusterserviceversion.yaml
@@ -216,7 +216,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-13T19:37:00Z"
+    createdAt: "2025-08-13T20:24:31Z"
     operators.operatorframework.io.bundle.channels.v1: stable,alpha
     operators.operatorframework.io.bundle.default.channel.v1: stable
     operators.operatorframework.io/builder: operator-sdk-v1.39.1

--- a/bundle/manifests/kivebpf.clusterserviceversion.yaml
+++ b/bundle/manifests/kivebpf.clusterserviceversion.yaml
@@ -52,6 +52,7 @@ metadata:
             "creationTimestamp": "2025-07-25T08:06:12Z",
             "generation": 1,
             "labels": {
+              "kernel-id": "fc9a30d5-6140-4dd1-b8ef-c638f19ebd71",
               "trap-id": "c4705ec263cc353100b6f18a129e32b67b79171bcb0c90b2731a7923ea4dcee"
             },
             "name": "kive-data-nginx-pod-default-13667586",
@@ -60,8 +61,8 @@ metadata:
             "uid": "788bcb67-a9de-480d-a179-e40234116459"
           },
           "spec": {
-            "inode-no": 13667586,
-            "kernel-id": "fc9a30d5-6140-4dd1-b8ef-c638f19ebd71"
+            "dev-id": 513,
+            "inode-no": 13667586
           }
         },
         {
@@ -215,7 +216,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-13T15:28:06Z"
+    createdAt: "2025-08-13T18:02:46Z"
     operators.operatorframework.io.bundle.channels.v1: stable,alpha
     operators.operatorframework.io.bundle.default.channel.v1: stable
     operators.operatorframework.io/builder: operator-sdk-v1.39.1

--- a/bundle/manifests/kivebpf.san7o.github.io_kivedata.yaml
+++ b/bundle/manifests/kivebpf.san7o.github.io_kivedata.yaml
@@ -57,9 +57,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernel-id:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string
@@ -103,9 +100,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernelId:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string

--- a/bundle/manifests/kivebpf.san7o.github.io_kivepolicies.yaml
+++ b/bundle/manifests/kivebpf.san7o.github.io_kivepolicies.yaml
@@ -75,7 +75,7 @@ spec:
                                - if this field is prepended by "regex:", the rest of the string
                                  will represent a regular expression matched with go regexp
                                  library (https://golang.org/s/re2syntax)
-                               - if the fiels is prepended by "glob:", then this is a
+                               - if the field is prepended by "glob:", then this is a
                                  filesystem-style regex, as described in go filepath.Match
                                  library (https://pkg.go.dev/path/filepath#Match)
                                - otherwise, the name of the container will be compared exactly

--- a/bundle/manifests/kivebpf.san7o.github.io_kivepolicies.yaml
+++ b/bundle/manifests/kivebpf.san7o.github.io_kivepolicies.yaml
@@ -71,8 +71,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP
@@ -157,8 +163,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -198,7 +198,8 @@ func main() {
 	}
 
 	if err = (&controller.KivePodReconciler{
-		Client: kivePodMgr.GetClient(),
+		Client:         kivePodMgr.GetClient(),
+		UncachedClient: kivePodMgr.GetAPIReader(),
 	}).SetupWithManager(kivePodMgr); err != nil {
 		setupLog.Error(err, "unable to create KivePod controller", "controller", "KivePod")
 		os.Exit(1)

--- a/config/crd/bases/kivebpf.san7o.github.io_kivedata.yaml
+++ b/config/crd/bases/kivebpf.san7o.github.io_kivedata.yaml
@@ -46,9 +46,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernel-id:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string
@@ -92,9 +89,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernelId:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/kivebpf.san7o.github.io_kivepolicies.yaml
+++ b/config/crd/bases/kivebpf.san7o.github.io_kivepolicies.yaml
@@ -64,7 +64,7 @@ spec:
                                - if this field is prepended by "regex:", the rest of the string
                                  will represent a regular expression matched with go regexp
                                  library (https://golang.org/s/re2syntax)
-                               - if the fiels is prepended by "glob:", then this is a
+                               - if the field is prepended by "glob:", then this is a
                                  filesystem-style regex, as described in go filepath.Match
                                  library (https://pkg.go.dev/path/filepath#Match)
                                - otherwise, the name of the container will be compared exactly

--- a/config/crd/bases/kivebpf.san7o.github.io_kivepolicies.yaml
+++ b/config/crd/bases/kivebpf.san7o.github.io_kivepolicies.yaml
@@ -60,8 +60,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP
@@ -146,8 +152,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP

--- a/config/samples/kive_v2alpha1_kivedata.yaml
+++ b/config/samples/kive_v2alpha1_kivedata.yaml
@@ -19,6 +19,7 @@ metadata:
   uid: 788bcb67-a9de-480d-a179-e40234116459
   labels:
     trap-id: c4705ec263cc353100b6f18a129e32b67b79171bcb0c90b2731a7923ea4dcee
+    kernel-id: fc9a30d5-6140-4dd1-b8ef-c638f19ebd71
 spec:
   inode-no: 13667586
-  kernel-id: fc9a30d5-6140-4dd1-b8ef-c638f19ebd71
+  dev-id: 513

--- a/config/samples/kive_v2alpha1_kivepolicy_regex.yaml
+++ b/config/samples/kive_v2alpha1_kivepolicy_regex.yaml
@@ -12,4 +12,4 @@ spec:
       mode: 444
       matchAny:
         - namespace: default
-          container-name: ".*"
+          containerName: "regex:ngi.*"

--- a/config/samples/kive_v2alpha1_kivepolicy_regex2.yaml
+++ b/config/samples/kive_v2alpha1_kivepolicy_regex2.yaml
@@ -13,4 +13,4 @@ spec:
       matchAny:
         - pod: nginx-pod
           namespace: default
-          container-name: "123.*"
+          containerName: "regex:123.*"

--- a/dist/install-dev.yaml
+++ b/dist/install-dev.yaml
@@ -196,7 +196,7 @@ spec:
                                - if this field is prepended by "regex:", the rest of the string
                                  will represent a regular expression matched with go regexp
                                  library (https://golang.org/s/re2syntax)
-                               - if the fiels is prepended by "glob:", then this is a
+                               - if the field is prepended by "glob:", then this is a
                                  filesystem-style regex, as described in go filepath.Match
                                  library (https://pkg.go.dev/path/filepath#Match)
                                - otherwise, the name of the container will be compared exactly

--- a/dist/install-dev.yaml
+++ b/dist/install-dev.yaml
@@ -192,8 +192,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP
@@ -278,8 +284,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP

--- a/dist/install-dev.yaml
+++ b/dist/install-dev.yaml
@@ -65,9 +65,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernel-id:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string
@@ -111,9 +108,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernelId:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string

--- a/dist/install-local.yaml
+++ b/dist/install-local.yaml
@@ -196,7 +196,7 @@ spec:
                                - if this field is prepended by "regex:", the rest of the string
                                  will represent a regular expression matched with go regexp
                                  library (https://golang.org/s/re2syntax)
-                               - if the fiels is prepended by "glob:", then this is a
+                               - if the field is prepended by "glob:", then this is a
                                  filesystem-style regex, as described in go filepath.Match
                                  library (https://pkg.go.dev/path/filepath#Match)
                                - otherwise, the name of the container will be compared exactly

--- a/dist/install-local.yaml
+++ b/dist/install-local.yaml
@@ -192,8 +192,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP
@@ -278,8 +284,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP

--- a/dist/install-local.yaml
+++ b/dist/install-local.yaml
@@ -65,9 +65,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernel-id:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string
@@ -111,9 +108,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernelId:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string

--- a/dist/install-remote.yaml
+++ b/dist/install-remote.yaml
@@ -196,7 +196,7 @@ spec:
                                - if this field is prepended by "regex:", the rest of the string
                                  will represent a regular expression matched with go regexp
                                  library (https://golang.org/s/re2syntax)
-                               - if the fiels is prepended by "glob:", then this is a
+                               - if the field is prepended by "glob:", then this is a
                                  filesystem-style regex, as described in go filepath.Match
                                  library (https://pkg.go.dev/path/filepath#Match)
                                - otherwise, the name of the container will be compared exactly

--- a/dist/install-remote.yaml
+++ b/dist/install-remote.yaml
@@ -192,8 +192,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP
@@ -278,8 +284,14 @@ spec:
                         properties:
                           containerName:
                             description: |-
-                              Filter container by name, can be a regex with syntax described at
-                              https://golang.org/s/re2syntax
+                              Filter container by name.
+                               - if this field is prepended by "regex:", the rest of the string
+                                 will represent a regular expression matched with go regexp
+                                 library (https://golang.org/s/re2syntax)
+                               - if the fiels is prepended by "glob:", then this is a
+                                 filesystem-style regex, as described in go filepath.Match
+                                 library (https://pkg.go.dev/path/filepath#Match)
+                               - otherwise, the name of the container will be compared exactly
                             type: string
                           ip:
                             description: Filter pods by IP

--- a/dist/install-remote.yaml
+++ b/dist/install-remote.yaml
@@ -65,9 +65,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernel-id:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string
@@ -111,9 +108,6 @@ spec:
                 description: The inode number of the file
                 format: int64
                 type: integer
-              kernelId:
-                description: A string to uniquely identify a running kernel
-                type: string
               metadata:
                 additionalProperties:
                   type: string

--- a/docs/APIv1.md
+++ b/docs/APIv1.md
@@ -43,7 +43,7 @@ type KiveTrapMatch struct {
     //  - if this field is prepended by "regex:", the rest of the string
     //    will represent a regular expression matched with go regexp
     //    library (https://golang.org/s/re2syntax)
-    //  - if the fiels is prepended by "glob:", then this is a
+    //  - if the field is prepended by "glob:", then this is a
     //    filesystem-style regex, as described in go filepath.Match
     //    library (https://pkg.go.dev/path/filepath#Match)
     //  - otherwise, the name of the container will be compared exactly

--- a/docs/APIv1.md
+++ b/docs/APIv1.md
@@ -37,11 +37,17 @@ type KiveTrap struct {
 
 // Match all the following optional fields (logical AND)
 type KiveTrapMatch struct {
-	// Filter pods by name
-	PodName string `json:"pod,omitempty"`
-	// Filter container by name, can be a regex with syntax described at
-	// https://golang.org/s/re2syntax
-	ContainerName string `json:"containerName,omitempty"`
+    // Filter pods by name
+    PodName string `json:"pod,omitempty"`
+    // Filter container by name.
+    //  - if this field is prepended by "regex:", the rest of the string
+    //    will represent a regular expression matched with go regexp
+    //    library (https://golang.org/s/re2syntax)
+    //  - if the fiels is prepended by "glob:", then this is a
+    //    filesystem-style regex, as described in go filepath.Match
+    //    library (https://pkg.go.dev/path/filepath#Match)
+    //  - otherwise, the name of the container will be compared exactly
+    ContainerName string `json:"containerName,omitempty"`
 	// Filter pods by namespace
 	Namespace string `json:"namespace,omitempty"`
 	// Filter pods by IP

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -538,12 +538,12 @@ metadata:
   uid: 788bcb67-a9de-480d-a179-e40234116459
   labels:
       trap-id: c4705ec263cc353100b6f18a129e32b67b79171bcb0c90b2731a7923ea4dcee
+      kernelId: fc9a30d5-6140-4dd1-b8ef-c638f19ebd71
 spec:
   inodeNo: 13667586
   devId: 3
   metadata:
     severity: critical
-  kernelId: fc9a30d5-6140-4dd1-b8ef-c638f19ebd71
 ```
 
 The fields under `spec` are:
@@ -552,14 +552,15 @@ The fields under `spec` are:
   eBPF program.
 - `devId`: The device id associated with the file to monitor.
 - `metadata`: Additional information to report in the alert.
-- `kernelId`: An unique identifier of a running kernel, to discriminate
-  which loader controller should handle this `KiveData`.
 
 The annotations are used as additional information for the `KiveAlert`
 when an access is detected by the eBPF program.
 
 The `trap-id` label is used to identify which `KiveTrap` generated
+this `KiveData`. The label `kernelId` is an unique identifier of a
+running kernel, to discriminate which loader controller should handle
 this `KiveData`.
+
 
 <a name="kivedata-reconciliation"></a>
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -390,7 +390,13 @@ items matched with a logical AND, which include:
 
 - `pod`: the name of the pod
 - `namespace`: the namespace of the pod
-- `container-name`: a regex to match the name of containers
+- `container-name`: the name of the container, or a patter to match the
+  name. There are three possible cases:
+  - if this field is prepended by `regex:`, the rest of the string
+    will represent a regular expression
+  - if the fiels is prepended by `glob:`, then this is a
+    filesystem-style regex, as described in go `filepath.Match`.
+  - otherwise, the name of the container will be compared exactly
 - `ip`: the ipv4 of the pod
 - `matchLabels`: a list of labels and values
 

--- a/docs/html/APIv1.html
+++ b/docs/html/APIv1.html
@@ -53,16 +53,22 @@
 <span id="cb1-31"><a href="#cb1-31" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> KiveTrapMatch <span class="kw">struct</span> <span class="op">{</span></span>
 <span id="cb1-32"><a href="#cb1-32" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by name</span></span>
 <span id="cb1-33"><a href="#cb1-33" aria-hidden="true" tabindex="-1"></a>    PodName <span class="dt">string</span> <span class="st">`json:&quot;pod,omitempty&quot;`</span></span>
-<span id="cb1-34"><a href="#cb1-34" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter container by name, can be a regex with syntax described at</span></span>
-<span id="cb1-35"><a href="#cb1-35" aria-hidden="true" tabindex="-1"></a>    <span class="co">// https://golang.org/s/re2syntax</span></span>
-<span id="cb1-36"><a href="#cb1-36" aria-hidden="true" tabindex="-1"></a>    ContainerName <span class="dt">string</span> <span class="st">`json:&quot;containerName,omitempty&quot;`</span></span>
-<span id="cb1-37"><a href="#cb1-37" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by namespace</span></span>
-<span id="cb1-38"><a href="#cb1-38" aria-hidden="true" tabindex="-1"></a>    Namespace <span class="dt">string</span> <span class="st">`json:&quot;namespace,omitempty&quot;`</span></span>
-<span id="cb1-39"><a href="#cb1-39" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by IP</span></span>
-<span id="cb1-40"><a href="#cb1-40" aria-hidden="true" tabindex="-1"></a>    IP <span class="dt">string</span> <span class="st">`json:&quot;ip,omitempty&quot;`</span></span>
-<span id="cb1-41"><a href="#cb1-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by label</span></span>
-<span id="cb1-42"><a href="#cb1-42" aria-hidden="true" tabindex="-1"></a>    MatchLabels <span class="kw">map</span><span class="op">[</span><span class="dt">string</span><span class="op">]</span><span class="dt">string</span> <span class="st">`json:&quot;matchLabels,omitempty&quot;`</span></span>
-<span id="cb1-43"><a href="#cb1-43" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb1-34"><a href="#cb1-34" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter container by name.</span></span>
+<span id="cb1-35"><a href="#cb1-35" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - if this field is prepended by &quot;regex:&quot;, the rest of the string</span></span>
+<span id="cb1-36"><a href="#cb1-36" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    will represent a regular expression matched with go regexp</span></span>
+<span id="cb1-37"><a href="#cb1-37" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    library (https://golang.org/s/re2syntax)</span></span>
+<span id="cb1-38"><a href="#cb1-38" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - if the fiels is prepended by &quot;glob:&quot;, then this is a</span></span>
+<span id="cb1-39"><a href="#cb1-39" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    filesystem-style regex, as described in go filepath.Match</span></span>
+<span id="cb1-40"><a href="#cb1-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    library (https://pkg.go.dev/path/filepath#Match)</span></span>
+<span id="cb1-41"><a href="#cb1-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - otherwise, the name of the container will be compared exactly</span></span>
+<span id="cb1-42"><a href="#cb1-42" aria-hidden="true" tabindex="-1"></a>    ContainerName <span class="dt">string</span> <span class="st">`json:&quot;containerName,omitempty&quot;`</span></span>
+<span id="cb1-43"><a href="#cb1-43" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by namespace</span></span>
+<span id="cb1-44"><a href="#cb1-44" aria-hidden="true" tabindex="-1"></a>    Namespace <span class="dt">string</span> <span class="st">`json:&quot;namespace,omitempty&quot;`</span></span>
+<span id="cb1-45"><a href="#cb1-45" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by IP</span></span>
+<span id="cb1-46"><a href="#cb1-46" aria-hidden="true" tabindex="-1"></a>    IP <span class="dt">string</span> <span class="st">`json:&quot;ip,omitempty&quot;`</span></span>
+<span id="cb1-47"><a href="#cb1-47" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Filter pods by label</span></span>
+<span id="cb1-48"><a href="#cb1-48" aria-hidden="true" tabindex="-1"></a>    MatchLabels <span class="kw">map</span><span class="op">[</span><span class="dt">string</span><span class="op">]</span><span class="dt">string</span> <span class="st">`json:&quot;matchLabels,omitempty&quot;`</span></span>
+<span id="cb1-49"><a href="#cb1-49" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <h2 id="kivealert">KiveAlert</h2>
 <div class="sourceCode" id="cb2"><pre class="sourceCode go"><code class="sourceCode go"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co">// File access alert</span></span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> KiveAlert <span class="kw">struct</span> <span class="op">{</span></span>

--- a/docs/html/APIv1.html
+++ b/docs/html/APIv1.html
@@ -57,7 +57,7 @@
 <span id="cb1-35"><a href="#cb1-35" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - if this field is prepended by &quot;regex:&quot;, the rest of the string</span></span>
 <span id="cb1-36"><a href="#cb1-36" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    will represent a regular expression matched with go regexp</span></span>
 <span id="cb1-37"><a href="#cb1-37" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    library (https://golang.org/s/re2syntax)</span></span>
-<span id="cb1-38"><a href="#cb1-38" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - if the fiels is prepended by &quot;glob:&quot;, then this is a</span></span>
+<span id="cb1-38"><a href="#cb1-38" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - if the field is prepended by &quot;glob:&quot;, then this is a</span></span>
 <span id="cb1-39"><a href="#cb1-39" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    filesystem-style regex, as described in go filepath.Match</span></span>
 <span id="cb1-40"><a href="#cb1-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">//    library (https://pkg.go.dev/path/filepath#Match)</span></span>
 <span id="cb1-41"><a href="#cb1-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">//  - otherwise, the name of the container will be compared exactly</span></span>

--- a/docs/html/DESIGN.html
+++ b/docs/html/DESIGN.html
@@ -354,8 +354,16 @@ match items matched with a logical AND, which include:</p>
 <ul>
 <li><code>pod</code>: the name of the pod</li>
 <li><code>namespace</code>: the namespace of the pod</li>
-<li><code>container-name</code>: a regex to match the name of
-containers</li>
+<li><code>container-name</code>: the name of the container, or a patter
+to match the name. There are three possible cases:
+<ul>
+<li>if this field is prepended by <code>regex:</code>, the rest of the
+string will represent a regular expression</li>
+<li>if the fiels is prepended by <code>glob:</code>, then this is a
+filesystem-style regex, as described in go
+<code>filepath.Match</code>.</li>
+<li>otherwise, the name of the container will be compared exactly</li>
+</ul></li>
 <li><code>ip</code>: the ipv4 of the pod</li>
 <li><code>matchLabels</code>: a list of labels and values</li>
 </ul>
@@ -477,12 +485,12 @@ class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb4-1"><a href="
 <span id="cb4-20"><a href="#cb4-20" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">uid</span><span class="kw">:</span><span class="at"> 788bcb67-a9de-480d-a179-e40234116459</span></span>
 <span id="cb4-21"><a href="#cb4-21" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">labels</span><span class="kw">:</span></span>
 <span id="cb4-22"><a href="#cb4-22" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">trap-id</span><span class="kw">:</span><span class="at"> c4705ec263cc353100b6f18a129e32b67b79171bcb0c90b2731a7923ea4dcee</span></span>
-<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a><span class="fu">spec</span><span class="kw">:</span></span>
-<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">inodeNo</span><span class="kw">:</span><span class="at"> </span><span class="dv">13667586</span></span>
-<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">devId</span><span class="kw">:</span><span class="at"> </span><span class="dv">3</span></span>
-<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">metadata</span><span class="kw">:</span></span>
-<span id="cb4-27"><a href="#cb4-27" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">severity</span><span class="kw">:</span><span class="at"> critical</span></span>
-<span id="cb4-28"><a href="#cb4-28" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">kernelId</span><span class="kw">:</span><span class="at"> fc9a30d5-6140-4dd1-b8ef-c638f19ebd71</span></span></code></pre></div>
+<span id="cb4-23"><a href="#cb4-23" aria-hidden="true" tabindex="-1"></a><span class="at">      </span><span class="fu">kernelId</span><span class="kw">:</span><span class="at"> fc9a30d5-6140-4dd1-b8ef-c638f19ebd71</span></span>
+<span id="cb4-24"><a href="#cb4-24" aria-hidden="true" tabindex="-1"></a><span class="fu">spec</span><span class="kw">:</span></span>
+<span id="cb4-25"><a href="#cb4-25" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">inodeNo</span><span class="kw">:</span><span class="at"> </span><span class="dv">13667586</span></span>
+<span id="cb4-26"><a href="#cb4-26" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">devId</span><span class="kw">:</span><span class="at"> </span><span class="dv">3</span></span>
+<span id="cb4-27"><a href="#cb4-27" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">metadata</span><span class="kw">:</span></span>
+<span id="cb4-28"><a href="#cb4-28" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">severity</span><span class="kw">:</span><span class="at"> critical</span></span></code></pre></div>
 <p>The fields under <code>spec</code> are:</p>
 <ul>
 <li><code>inodeNo</code>: The inode number of the file to monitor,
@@ -491,15 +499,15 @@ needed by the eBPF program.</li>
 monitor.</li>
 <li><code>metadata</code>: Additional information to report in the
 alert.</li>
-<li><code>kernelId</code>: An unique identifier of a running kernel, to
-discriminate which loader controller should handle this
-<code>KiveData</code>.</li>
 </ul>
 <p>The annotations are used as additional information for the
 <code>KiveAlert</code> when an access is detected by the eBPF
 program.</p>
 <p>The <code>trap-id</code> label is used to identify which
-<code>KiveTrap</code> generated this <code>KiveData</code>.</p>
+<code>KiveTrap</code> generated this <code>KiveData</code>. The label
+<code>kernelId</code> is an unique identifier of a running kernel, to
+discriminate which loader controller should handle this
+<code>KiveData</code>.</p>
 <p><a name="kivedata-reconciliation"></a></p>
 <h3 id="kivedata-reconciliation">KiveData Reconciliation</h3>
 <p>Upon CRUD changes of the <code>KiveData</code> resource, the

--- a/internal/controller/comm/comm.go
+++ b/internal/controller/comm/comm.go
@@ -1,0 +1,6 @@
+package comm
+
+const (
+	// Label used for keeping the kernel ID
+	KernelIDLabel = "kernel-id"
+)

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -7,6 +7,6 @@ const (
 	// Where to find the identifier of this running kernel
 	KernelIDPath = "/proc/sys/kernel/random/boot_id"
 
-	// Label used for the trap identifier
-	TrapIdLabel = "trap-id"
+	// Label used to store the trap identifier
+	TrapIDLabel = "trap-id"
 )

--- a/internal/controller/ebpf/ebpf.go
+++ b/internal/controller/ebpf/ebpf.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kivev2alpha1 "github.com/San7o/kivebpf/api/v2alpha1"
+	comm "github.com/San7o/kivebpf/internal/controller/comm"
 	container "github.com/San7o/kivebpf/internal/controller/container"
 )
 
@@ -212,7 +213,7 @@ func ReadAlert(ctx context.Context, cli client.Reader) (kivev2alpha1.KiveAlert, 
 					Path:     kiveData.Annotations["path"],
 					Inode:    data.Ino,
 					Mask:     data.Mask,
-					KernelID: kiveData.Spec.KernelID,
+					KernelID: kiveData.ObjectMeta.Labels[comm.KernelIDLabel],
 					Callback: kiveData.ObjectMeta.Annotations["callback"],
 				},
 				CustomMetadata: map[string]string{},

--- a/internal/controller/kivedata_controller.go
+++ b/internal/controller/kivedata_controller.go
@@ -107,8 +107,7 @@ Data:
 
 				err := ebpf.RemoveInode(ebpf.BpfMapKey{Inode: kiveData.Spec.InodeNo, Dev: kiveData.Spec.DevID})
 				if err != nil {
-					log.Error(err, fmt.Sprintf("Reconcile Error Remove Inode during deletion of KiveData %s", kiveData.Name))
-					return ctrl.Result{Requeue: true}, nil
+					log.Info("Reconcile Error Remove Inode during deletion of KiveData %s: %w", kiveData.Name, err)
 				}
 
 				controllerutil.RemoveFinalizer(kiveDataCopy, KiveDataFinalizerName)

--- a/internal/controller/kivedata_controller.go
+++ b/internal/controller/kivedata_controller.go
@@ -25,6 +25,7 @@ import (
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kivev2alpha1 "github.com/San7o/kivebpf/api/v2alpha1"
+	comm "github.com/San7o/kivebpf/internal/controller/comm"
 	ebpf "github.com/San7o/kivebpf/internal/controller/ebpf"
 )
 
@@ -55,8 +56,11 @@ func (r *KiveDataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		go Output(r.UncachedClient)
 	}
 
+	kiveDataLabels := client.MatchingLabels{
+		comm.KernelIDLabel: KernelID,
+	}
 	kiveDataList := &kivev2alpha1.KiveDataList{}
-	err := r.Client.List(ctx, kiveDataList)
+	err := r.Client.List(ctx, kiveDataList, kiveDataLabels)
 	if err != nil { // Fatal
 		return ctrl.Result{}, fmt.Errorf("Reconcile Error Failed to get Kive Data resource: %w", err)
 	}
@@ -74,10 +78,6 @@ func (r *KiveDataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// deleted.
 Data:
 	for _, kiveData := range kiveDataList.Items {
-
-		if kiveData.Spec.KernelID != KernelID {
-			continue Data
-		}
 
 		// Check if there is a finalizer
 		if !controllerutil.ContainsFinalizer(&kiveData, KiveDataFinalizerName) {

--- a/internal/controller/kivepolicy_controller.go
+++ b/internal/controller/kivepolicy_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kivev2alpha1 "github.com/San7o/kivebpf/api/v2alpha1"
+	comm "github.com/San7o/kivebpf/internal/controller/comm"
 	container "github.com/San7o/kivebpf/internal/controller/container"
 )
 
@@ -133,7 +134,7 @@ Policy:
 			for _, kiveTrapMatch := range kiveTrap.MatchAny {
 
 				labels := client.MatchingLabels{
-					TrapIdLabel: trapID,
+					TrapIDLabel: trapID,
 				}
 				kiveDataList := &kivev2alpha1.KiveDataList{}
 				err = r.UncachedClient.List(ctx, kiveDataList, labels)
@@ -227,14 +228,14 @@ Policy:
 								},
 								Labels: map[string]string{
 									// The trap-id is used to link this KiveData to this trap
-									TrapIdLabel: trapID,
+									TrapIDLabel:        trapID,
+									comm.KernelIDLabel: KernelID,
 								},
 								Finalizers: []string{KiveDataFinalizerName},
 							},
 							Spec: kivev2alpha1.KiveDataSpec{
 								InodeNo:  inode,
 								DevID:    dev,
-								KernelID: KernelID,
 								Metadata: map[string]string{},
 							},
 						}

--- a/internal/controller/kivepolicy_controller.go
+++ b/internal/controller/kivepolicy_controller.go
@@ -133,15 +133,6 @@ Policy:
 		Match:
 			for _, kiveTrapMatch := range kiveTrap.MatchAny {
 
-				labels := client.MatchingLabels{
-					TrapIDLabel: trapID,
-				}
-				kiveDataList := &kivev2alpha1.KiveDataList{}
-				err = r.UncachedClient.List(ctx, kiveDataList, labels)
-				if err != nil { // Fatal
-					return ctrl.Result{}, fmt.Errorf("Reconcile Error Failed to get KiveData resource: %w", err)
-				}
-
 				// Get Pods that match this KiveTrap
 				labelMap := make(client.MatchingLabels)
 				labelMap = kiveTrapMatch.MatchLabels

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -17,8 +17,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -59,12 +61,26 @@ func RegexMatch(regex string, containerName string) (bool, error) {
 		return true, nil
 	}
 
-	compiledRegex, err := regexp.Compile(regex)
-	if err != nil {
-		return false, fmt.Errorf("RegexMatch Error compiling regex: %w", err)
+	if strings.HasPrefix(regex, "regex:") {
+
+		compiledRegex, err := regexp.Compile(strings.TrimPrefix(regex, "regex:"))
+		if err != nil {
+			return false, fmt.Errorf("RegexMatch Error compiling regex: %w", err)
+		}
+
+		return compiledRegex.Match([]byte(containerName)), nil
+
+	} else if strings.HasPrefix(regex, "glob:") {
+
+		result, err := filepath.Match(strings.TrimPrefix(regex, "glob:"), containerName)
+		if err != nil {
+			return false, fmt.Errorf("RegexMatch Error compiling regex: %w", err)
+		}
+		return result, nil
 	}
 
-	return compiledRegex.Match([]byte(containerName)), nil
+	// Direct comparison
+	return regex == containerName, nil
 }
 
 func KiveDataTrapCmp(kiveData kivev2alpha1.KiveData, kiveTrap kivev2alpha1.KiveTrap) (bool, error) {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -73,7 +73,7 @@ func KiveDataTrapCmp(kiveData kivev2alpha1.KiveData, kiveTrap kivev2alpha1.KiveT
 	if err != nil {
 		return false, fmt.Errorf("KiveDataTrapCmp Error Hash ID: %w", err)
 	}
-	return kiveData.ObjectMeta.Labels[TrapIdLabel] == trapID, nil
+	return kiveData.ObjectMeta.Labels[TrapIDLabel] == trapID, nil
 }
 
 func KiveDataContainerCmp(kiveData kivev2alpha1.KiveData, pod corev1.Pod, containerStatus corev1.ContainerStatus) bool {

--- a/test/e2e/e2e_containername_regex_test.go
+++ b/test/e2e/e2e_containername_regex_test.go
@@ -44,7 +44,7 @@ var _ = Describe("ContainerName Regex", Ordered, func() {
 						kivev2alpha1.KiveTrapMatch{
 							PodName:       "test-pod",
 							Namespace:     "kive-test",
-							ContainerName: "test-ngi.*",
+							ContainerName: "regex:test-ngi.*",
 						},
 					},
 				},

--- a/test/e2e/e2e_containername_regex_test2.go
+++ b/test/e2e/e2e_containername_regex_test2.go
@@ -42,7 +42,7 @@ var _ = Describe("ContainerName Regex 2", Ordered, func() {
 						kivev2alpha1.KiveTrapMatch{
 							PodName:       "test-pod",
 							Namespace:     "kive-test",
-							ContainerName: "test-nope.*",
+							ContainerName: "regex:test-nope.*",
 						},
 					},
 				},


### PR DESCRIPTION
This PR introduces multiple regex matching styles for the container name.

The `containerName` field in a `KivePolicy` trap allows these cases:
  - if this field is prepended by `regex:`, the rest of the string will represent a regular expression matched with go [regexp](https://golang.org/s/re2syntax) library.
  - if the field is prepended by "glob:", then this is a filesystem-style regex, as described in go [filepath.Match](https://pkg.go.dev/path/filepath#Match) library
  - if it is empty, the trap is deployed in all containers in the matched pods.
  - otherwise, the name of the container will be compared exactly

  The default value is empty.

Additionally, the `KernelID` field in a `KiveData` was moved to a label
so the controllers can get only the resources relevant to their kernel
instead of getting all the resources filtering them during reconciliation.

An unnecessary list of `KiveData` was removed from the `KivePolicy`
reconciler.